### PR TITLE
restore classic Summary statistics page

### DIFF
--- a/src/themes/classic/components/ActivityList/ActivityChart.tsx
+++ b/src/themes/classic/components/ActivityList/ActivityChart.tsx
@@ -21,7 +21,7 @@ interface ActivityChartProps {
 }
 
 const ActivityChart = ({ data, yAxisMax, yAxisTicks }: ActivityChartProps) => (
-  <ResponsiveContainer>
+  <ResponsiveContainer initialDimension={{ width: 248, height: 250 }}>
     <BarChart data={data} margin={{ top: 20, right: 20, left: -20, bottom: 5 }}>
       <CartesianGrid
         strokeDasharray="3 3"

--- a/src/themes/classic/index.tsx
+++ b/src/themes/classic/index.tsx
@@ -1,8 +1,10 @@
 import './styles/index.css';
-import { Suspense } from 'react';
+import { lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import Index from './pages/index';
+
+const Summary = lazy(() => import('./pages/summary'));
 
 export default function ClassicTheme() {
   return (
@@ -10,6 +12,8 @@ export default function ClassicTheme() {
       <BrowserRouter>
         <Suspense fallback={<div>Loading...</div>}>
           <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/summary" element={<Summary />} />
             <Route path="*" element={<Index />} />
           </Routes>
         </Suspense>

--- a/src/themes/classic/pages/summary.tsx
+++ b/src/themes/classic/pages/summary.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { Helmet } from 'react-helmet-async';
+import ActivityList from '../components/ActivityList';
+import { useTheme } from '../hooks/useTheme';
+
+const SummaryPage = () => {
+  const { theme } = useTheme();
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
+  return (
+    <>
+      <Helmet>
+        <html lang="zh-CN" data-theme={theme} />
+        <title>Running Summary</title>
+      </Helmet>
+      <ActivityList />
+    </>
+  );
+};
+
+export default SummaryPage;


### PR DESCRIPTION
## 修复内容

- 恢复 classic 主题的 `/summary` 显式路由
- 复用现有 ActivityList，恢复月度、年度和生命周期统计
- 修复 Recharts 初始尺寸警告

## 验证

- 直接访问和刷新 `/summary` 正常
- 首页与 Summary 双向导航正常
- 月度统计卡片和 9 个图表正常显示
- F12 控制台 0 错误/警告
- Prettier、ESLint（0 errors）和生产构建通过