### PR TITLE
match hidden Mapbox background to the page theme

### DIFF
--- a/src/themes/classic/components/RunMap/index.tsx
+++ b/src/themes/classic/components/RunMap/index.tsx
@@ -106,9 +106,10 @@ const RunMap = ({
   const switchLayerVisibility = useCallback(
     (map: MapInstance, nextLights: boolean) => {
       const styleJson = map.getStyle();
-      const pageBackgroundColor = getComputedStyle(
-        document.body
-      ).backgroundColor;
+      const pageTheme = document.documentElement.getAttribute('data-theme');
+      // Tailwind exposes these colors as oklch(), which Mapbox GL does not
+      // currently accept. Use the equivalent neutral-100/900 hex values.
+      const pageBackgroundColor = pageTheme === 'light' ? '#f5f5f5' : '#171717';
 
       styleJson.layers.forEach((it: { id: string; type?: string }) => {
         // Without a visible background layer Mapbox clears the WebGL canvas to

--- a/src/themes/classic/components/RunMap/index.tsx
+++ b/src/themes/classic/components/RunMap/index.tsx
@@ -106,7 +106,26 @@ const RunMap = ({
   const switchLayerVisibility = useCallback(
     (map: MapInstance, nextLights: boolean) => {
       const styleJson = map.getStyle();
-      styleJson.layers.forEach((it: { id: string }) => {
+      const pageBackgroundColor = getComputedStyle(
+        document.body
+      ).backgroundColor;
+
+      styleJson.layers.forEach((it: { id: string; type?: string }) => {
+        // Without a visible background layer Mapbox clears the WebGL canvas to
+        // pure black, which creates a noticeable rectangle on the themed page.
+        // Keep the layer visible and match it to the resolved page background.
+        if (it.type === 'background') {
+          if (!nextLights && pageBackgroundColor) {
+            map.setPaintProperty(
+              it.id,
+              'background-color',
+              pageBackgroundColor
+            );
+          }
+          map.setLayoutProperty(it.id, 'visibility', 'visible');
+          return;
+        }
+
         if (!KEEP_WHEN_LIGHTS_OFF.includes(it.id)) {
           if (nextLights) map.setLayoutProperty(it.id, 'visibility', 'visible');
           else map.setLayoutProperty(it.id, 'visibility', 'none');


### PR DESCRIPTION
## 问题

关闭地图底图时，Mapbox 的背景图层也被隐藏，WebGL 画布会退回纯黑色；黑色主题页面背景实际为深灰色，因此出现明显矩形色块。

## 修复

- 保持 Mapbox background 图层可见
- 关闭底图时使用浏览器计算出的页面背景色
- 同时适配深色和浅色主题

## 验证

- Prettier 检查通过
- ESLint 通过（0 errors）
- 生产构建通过