### PR TITLE
optimize classic initial page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,13 @@
       })();
     </script>
     <link rel="icon" type="image/png" href="%BASE_URL%/images/favicon.png" />
+    <link
+      rel="preload"
+      href="/src/static/activities.json"
+      as="fetch"
+      type="application/json"
+      crossorigin
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Running Page</title>
   </head>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,12 @@
       type="application/json"
       crossorigin
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100..700;1,100..700&amp;family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&amp;display=swap"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Running Page</title>
   </head>

--- a/src/themes/classic/pages/index.tsx
+++ b/src/themes/classic/pages/index.tsx
@@ -1,4 +1,6 @@
 import {
+  lazy,
+  Suspense,
   useEffect,
   useState,
   useMemo,
@@ -10,14 +12,13 @@ import { Analytics } from '@vercel/analytics/react';
 import { Helmet } from 'react-helmet-async';
 import Layout from '../components/Layout';
 import LocationStat from '../components/LocationStat';
-import RunMap from '../components/RunMap';
 import RunTable from '../components/RunTable';
 import SVGStat from '../components/SVGStat';
 import YearsStat from '../components/YearsStat';
 import useActivities from '../hooks/useActivities';
 import getSiteMetadata from '@core/hooks/useSiteMetadata';
 import { useInterval } from '@core/hooks/useInterval';
-import { IS_CHINESE } from '../utils/const';
+import { IS_CHINESE, MAP_HEIGHT } from '../utils/const';
 import {
   Activity,
   filterAndSortRuns,
@@ -37,6 +38,17 @@ import {
 import { useTheme, useThemeChangeCounter } from '../hooks/useTheme';
 
 const HASH_RUN_CHANGE_EVENT = 'running-page-hash-run-change';
+const RunMap = lazy(() => import('../components/RunMap'));
+
+const MapLoadingFallback = () => (
+  <div
+    aria-label="Loading map"
+    className="flex w-full items-center justify-center"
+    style={{ height: MAP_HEIGHT, color: 'var(--color-run-date)' }}
+  >
+    Loading map...
+  </div>
+);
 
 const getRunIdFromHash = () => {
   if (typeof window === 'undefined') return null;
@@ -425,15 +437,17 @@ const Index = () => {
         )}
       </div>
       <div className="w-full lg:w-2/3" id="map-container">
-        <RunMap
-          title={title}
-          viewState={viewState}
-          geoData={animatedGeoData}
-          setViewState={setViewState}
-          changeYear={changeYear}
-          thisYear={year}
-          animationTrigger={animationTrigger}
-        />
+        <Suspense fallback={<MapLoadingFallback />}>
+          <RunMap
+            title={title}
+            viewState={viewState}
+            geoData={animatedGeoData}
+            setViewState={setViewState}
+            changeYear={changeYear}
+            thisYear={year}
+            animationTrigger={animationTrigger}
+          />
+        </Suspense>
         {year === 'Total' ? (
           <SVGStat />
         ) : (

--- a/src/themes/classic/styles/index.css
+++ b/src/themes/classic/styles/index.css
@@ -1,7 +1,3 @@
-/* IBM Plex Sans and IBM Plex Mono fonts */
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap');
-
 @import 'tailwindcss';
 @import './mobile.css';
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -96,7 +96,6 @@ export default defineConfig({
   },
   build: {
     manifest: true,
-    modulePreload: false,
     outDir: './dist',
   },
 });


### PR DESCRIPTION
## 问题

classic 首页会让全屏 `Loading...` 同时等待活动数据和约 468 KB（gzip）的 Mapbox 主包。在网络延迟较高时，地图下载会阻塞整页首屏。

## 优化

- 将 RunMap / Mapbox 拆成独立懒加载模块，页面内容优先显示
- 从 HTML 阶段预加载活动数据
- 恢复 Vite module preload，使动态依赖并行下载
- 合并 Google Fonts 请求并提前建立连接
- 保留固定高度地图占位，避免加载时布局跳动

## 构建结果

- classic 首屏模块从约 54.8 KB 拆分为 17.9 KB
- RunMap 独立模块约 38.1 KB，Mapbox 在地图区域内异步加载
- Vercel 和 GitHub Pages `/running/` 前缀构建均通过

## 验证

- Prettier 通过
- ESLint 通过（0 errors）
- 生产构建通过
- Vercel 分支预览地图正常
- Summary 统计和图表正常
- 控制台 0 errors / warnings